### PR TITLE
Add fallback for dateFormat

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -1,1 +1,1 @@
-<li><time>{{ .Date.Format .Site.Params.dateFormat }}</time> - <a href="{{ .Permalink }}">{{ .Title }}</a></li>
+<li><time>{{ with .Site.Params.dateFormat }}{{ .Date.Format . }}{{ else }}{{ .Date.Format "02 Jan 2006, 15:04" }}{{ end }}</time> - <a href="{{ .Permalink }}">{{ .Title }}</a></li>

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -2,7 +2,7 @@
 
   <div>
     <i class="fa fa-calendar fa-fw"></i>
-    <time>{{ .Date.Format .Site.Params.dateFormat }}</time>
+    <time>{{ with .Site.Params.dateFormat }}{{ .Date.Format . }}{{ else }}{{ .Date.Format "02 Jan 2006, 15:04" }}{{ end }}</time>
   </div>
 
   {{ $baseUrl := .Site.BaseURL }}


### PR DESCRIPTION
To avoid numerous template error messages when the end user does not define [params] dateFormat in config.toml