### PR TITLE
Add additional social item for Hacker News and unify logo appearance

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -9,13 +9,13 @@
 
     {{ with .Site.Social.twitter }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://twitter.com/{{ . }}" target="_blank"><i class="fa fa-twitter fa-fw"></i>Twitter</a>
+      <a class="pure-menu-link" href="https://twitter.com/{{ . }}" target="_blank"><i class="fa fa-twitter-square fa-fw"></i>Twitter</a>
     </li>
     {{ end }}
 
     {{ with .Site.Social.facebook }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://facebook.com/{{ . }}" target="_blank"><i class="fa fa-facebook fa-fw"></i>Facebook</a>
+      <a class="pure-menu-link" href="https://facebook.com/{{ . }}" target="_blank"><i class="fa fa-facebook-square fa-fw"></i>Facebook</a>
     </li>
     {{ end }}
 
@@ -79,7 +79,7 @@
 
     {{ with .Site.Social.linkedin }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://linkedin.com/in/{{ . }}" target="_blank"><i class="fa fa-linkedin fa-fw"></i>LinkedIn</a>
+      <a class="pure-menu-link" href="https://linkedin.com/in/{{ . }}" target="_blank"><i class="fa fa-linkedin-square fa-fw"></i>LinkedIn</a>
     </li>
     {{ end }}
 
@@ -93,7 +93,7 @@
 
     {{ with .Site.Social.reddit }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://reddit.com/user/{{ . }}" target="_blank"><i class="fa fa-reddit fa-fw"></i>Reddit</a>
+      <a class="pure-menu-link" href="https://reddit.com/user/{{ . }}" target="_blank"><i class="fa fa-reddit-square fa-fw"></i>Reddit</a>
     </li>
     {{ end }}
 
@@ -101,7 +101,7 @@
 
     {{ with .Site.Social.github }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://github.com/{{ . }}" target="_blank"><i class="fa fa-github-alt fa-fw"></i>GitHub</a>
+      <a class="pure-menu-link" href="https://github.com/{{ . }}" target="_blank"><i class="fa fa-github-square fa-fw"></i>GitHub</a>
     </li>
     {{ end }}
 
@@ -114,6 +114,12 @@
     {{ with .Site.Social.stackoverflow }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://stackoverflow.com/users/{{ . }}" target="_blank"><i class="fa fa-stack-overflow fa-fw"></i>Stack Overflow</a>
+    </li>
+    {{ end }}
+
+    {{ with .Site.Social.hackernews }}
+    <li class="pure-menu-item">
+      <a class="pure-menu-link" href="https://news.ycombinator.com/user?id={{ . }}" target="_blank"><i class="fa fa-hacker-news fa-fw"></i>Hacker News</a>
     </li>
     {{ end }}
 

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -47,19 +47,19 @@
 
     {{ with .Site.Social.pinterest }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://pinterest.com/{{ . }}" target="_blank"><i class="fa fa-pinterest fa-fw"></i>Pinterest</a>
+      <a class="pure-menu-link" href="https://pinterest.com/{{ . }}" target="_blank"><i class="fa fa-pinterest-square fa-fw"></i>Pinterest</a>
     </li>
     {{ end }}
 
     {{ with .Site.Social.youtube }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://youtube.com/user/{{ . }}" target="_blank"><i class="fa fa-youtube fa-fw"></i>YouTube</a>
+      <a class="pure-menu-link" href="https://youtube.com/user/{{ . }}" target="_blank"><i class="fa fa-youtube-square fa-fw"></i>YouTube</a>
     </li>
     {{ end }}
 
     {{ with .Site.Social.vimeo }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://vimeo.com/{{ . }}" target="_blank"><i class="fa fa-vimeo fa-fw"></i>Vimeo</a>
+      <a class="pure-menu-link" href="https://vimeo.com/{{ . }}" target="_blank"><i class="fa fa-vimeo-square fa-fw"></i>Vimeo</a>
     </li>
     {{ end }}
 
@@ -85,7 +85,7 @@
 
     {{ with .Site.Social.xing }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://xing.com/profile/{{ . }}" target="_blank"><i class="fa fa-xing fa-fw"></i>Xing</a>
+      <a class="pure-menu-link" href="https://xing.com/profile/{{ . }}" target="_blank"><i class="fa fa-xing-square fa-fw"></i>Xing</a>
     </li>
     {{ end }}
 
@@ -107,7 +107,7 @@
 
     {{ with .Site.Social.bitbucket }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https:////bitbucket.org/{{ . }}" target="_blank"><i class="fa fa-bitbucket fa-fw"></i>Bitbucket</a>
+      <a class="pure-menu-link" href="https:////bitbucket.org/{{ . }}" target="_blank"><i class="fa fa-bitbucket-square fa-fw"></i>Bitbucket</a>
     </li>
     {{ end }}
 


### PR DESCRIPTION
Howdy,

I noticed that some logos were square and some were not.  Font Awesome provides square versions of almost all of the logos that are otherwise not square, and switching to them helps provide a unified appearance for the social logos.  So that's one of the changes within.  The other change was to add an entry for Hacker News.

Thanks.