### PR TITLE
Fix a bug where the index would have empty pages

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,10 +6,8 @@
 </div>
 
 <div class="content">
-  {{ range .Paginator.Pages }}
-    {{ if eq .Type "post" }}
-      {{ .Render "summary"}}
-    {{ end }}
+  {{ range ( .Paginate (where .Data.Pages "Type" "post")).Pages }}
+    {{ .Render "summary"}}
   {{ end }}
 
   {{ partial "pagination.html" . }}


### PR DESCRIPTION
If you have pages that aren't the post type, the pagination would cause empty index pages.

To reproduce:
* Create a lot (10+) of pages that aren't "post" type
* Create a post
* Load the index page, and note that the pagination has more than 1 page, but only 1 post