### PR TITLE
Update prev_next_post template to use .NextInSection and .PrevInSection

### DIFF
--- a/layouts/partials/prev_next_post.html
+++ b/layouts/partials/prev_next_post.html
@@ -1,16 +1,16 @@
 {{ if or (.Prev) (.Next) }}
 <div class="prev-next-post pure-g">
   <div class="pure-u-1 pure-u-md-1-2">
-    {{ if .Prev }}
+    {{ if .PrevInSection }}
     <nav class="prev">
-      <a href="{{ .Prev.Permalink }}"><i class="fa fa-arrow-circle-left fa-fw fa-lg"></i>{{ .Prev.Title }}</a>
+      <a href="{{ .PrevInSection.Permalink }}"><i class="fa fa-arrow-circle-left fa-fw fa-lg"></i>{{ .PrevInSection.Title }}</a>
     </nav>
     {{ end }}
   </div>
   <div class="pure-u-1 pure-u-md-1-2">
-    {{ if .Next }}
+    {{ if .NextInSection }}
     <nav class="next">
-      <a href="{{ .Next.Permalink }}">{{ .Next.Title }}<i class="fa fa-arrow-circle-right fa-fw fa-lg"></i></a>
+      <a href="{{ .NextInSection.Permalink }}">{{ .NextInSection.Title }}<i class="fa fa-arrow-circle-right fa-fw fa-lg"></i></a>
     </nav>
     {{ end }}
   </div>


### PR DESCRIPTION
These were introduced in Hugo 0.12.0

This fixes an issue I was seeing where the 'next' page for a post was the top level 'about' page