### PR TITLE
Use .RSSlink rather than manually building link

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,7 +33,9 @@
   <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet" type="text/css">
 
   <!-- RSS -->
-  <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .Site.BaseURL }}index.xml" />
+  {{ if .RSSlink }}
+  <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSlink }}" />
+  {{ end }}
 
   {{ with .Site.Params.highlightjs }}
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.1.0/styles/{{ . }}.min.css">

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,9 +1,11 @@
 <div class="pure-menu social">
   <ul class="pure-menu-list">
 
+    {{ if .RSSlink }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="{{ .Site.BaseURL }}index.xml"><i class="fa fa-rss fa-fw"></i>RSS</a>
+      <a class="pure-menu-link" href="{{ .RSSlink }}"><i class="fa fa-rss fa-fw"></i>RSS</a>
     </li>
+    {{ end }}
 
     <!-- SNS microblogging -->
 


### PR DESCRIPTION
Previously it was possible to create a nonexist link. If `Site.BaseURL` didn't end in a `/` the
constructed RSS link would be of the form `http://mysite.comindex.xml`

See https://gohugo.io/templates/rss/ for details on `RSSLink`