### PR TITLE
Add social icon for Keybase.io

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -124,6 +124,12 @@
       <a class="pure-menu-link" href="https://stackoverflow.com/users/{{ . }}" target="_blank"><i class="fa fa-stack-overflow fa-fw"></i>Stack Overflow</a>
     </li>
     {{ end }}
+    
+    {{ with .Site.Social.keybase }}
+    <li class="pure-menu-item">
+      <a class="pure-menu-link" href="https://keybase.io/{{ . }}" target="_blank"><i class="fa fa-key fa-fw"></i>Keybase</a>
+    </li>
+    {{ end }}
 
   </ul>
 </div>


### PR DESCRIPTION
[Keybase.io](https://keybase.io/) is a social proof service which allows users to ease the burden of PGP.  It uses the online social accounts + signed proofs as a basis for identity verification and provides high-performance tooling written in Go to interact with PGP and NaCL for sending and receiving encrypted messages from users, certifying ownership of devices, tracking users, and transferring encrypted files with KBFS.  It also acts as a central public place where you can provide cross-verified ownership of your social media accounts.

Currently Keybase.io does not have an icon in Font Awesome, so the fairly standard use case now is to substitute `fa-key` which is what I've done here.

[My Keybase profile](https://keybase.io/tristor) can serve as an example for what someone might link to with this social partial.

Thanks.