### PR TITLE
Adding GNUSocial as a social item in sidebar

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -17,7 +17,7 @@
 
     {{ with .Site.Social.gnusocial }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://quitter.se/{{ . }}" target="_blank"><i class="fa fa-comment fa-fw"></i>GNUSocial</a>
+      <a class="pure-menu-link" href="{{ . }}" target="_blank"><i class="fa fa-comment fa-fw"></i>GNU social</a>
     </li>
     {{ end }}
 

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -15,7 +15,7 @@
     </li>
     {{ end }}
 
-    {{ with .Site.Social.GNUSocial }}
+    {{ with .Site.Social.gnusocial }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://quitter.se/{{ . }}" target="_blank"><i class="fa fa-gnusocial-square fa-fw"></i>Twitter</a>
     </li>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -15,6 +15,12 @@
     </li>
     {{ end }}
 
+    {{ with .Site.Social.GNUSocial }}
+    <li class="pure-menu-item">
+      <a class="pure-menu-link" href="https://quitter.se/{{ . }}" target="_blank"><i class="fa fa-gnusocial-square fa-fw"></i>Twitter</a>
+    </li>
+    {{ end }}
+
     {{ with .Site.Social.facebook }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://facebook.com/{{ . }}" target="_blank"><i class="fa fa-facebook-square fa-fw"></i>Facebook</a>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -17,7 +17,7 @@
 
     {{ with .Site.Social.gnusocial }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://quitter.se/{{ . }}" target="_blank"><i class="fa fa-gnusocial-square fa-fw"></i>Twitter</a>
+      <a class="pure-menu-link" href="https://quitter.se/{{ . }}" target="_blank"><i class="fa fa-gnusocial-square fa-fw"></i>GNUSocial</a>
     </li>
     {{ end }}
 

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -17,7 +17,7 @@
 
     {{ with .Site.Social.gnusocial }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://quitter.se/{{ . }}" target="_blank"><i class="fa fa-gnusocial-square fa-fw"></i>GNUSocial</a>
+      <a class="pure-menu-link" href="https://quitter.se/{{ . }}" target="_blank"><i class="fa fa-comment fa-fw"></i>GNUSocial</a>
     </li>
     {{ end }}
 


### PR DESCRIPTION
GNUSocial is similar to Twitter, but an open-source project. The thing is, that users could very well be on different instances than the one I've listed. I am open to ideas on how to solve it.

As for the icon, Font Awesome does not have a GNUSocial icon, so I'm using the `fa-comment` icon instead, in line with @Tristor 's work on Keybase.