### PR TITLE
Add a default taxonomy list template

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,13 @@
+{{ partial "header.html" . }}
+
+<div class="header">
+  <h1>{{ .Title }}</h1>
+</div>
+
+<div class="content">
+  {{ range .Data.Pages }}
+    {{ .Render "summary"}}
+  {{ end }}
+</div>
+
+{{ partial "footer.html" . }}


### PR DESCRIPTION
Without the default, taxonomies like "categories" or "authors" don't render their lists of items.

I copied the taxonomy/tag.html template. I think the tag & topic taxonomy templates can be deleted, if you want.

[Docs](https://gohugo.io/templates/list/#taxonomy-lists)
