### PR TITLE
Restrict image width to layout width

### DIFF
--- a/static/css/blackburn.css
+++ b/static/css/blackburn.css
@@ -75,3 +75,7 @@ i {
 .pagination a {
   color: #265778;
 }
+
+img {
+  max-width: 100%;
+}


### PR DESCRIPTION
Currently, if the width of an image is bigger than the width of the layout the image sticks out of the layout - even causing a vertical scroll bar to appear if the image is big enough.

This pull request aims to fix that issue by shrinking images which are too big to the width of the layout.
