### PR TITLE
Add MobyGames to social links (gaming)

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -151,6 +151,13 @@
     </li>
     {{ end }}
 
+    
+    {{ with .Site.Social.mobygames }}
+    <li class="pure-menu-item">
+      <a class="pure-menu-link" href="https://www.mobygames.com/developer/sheet/view/developerId,{{ . }}" target="_blank"><i class="fa fa-gamepad fa-fw"></i>MobyGames</a>
+    </li>
+    {{ end }}
+
     <!-- Music -->
 
     {{ with .Site.Social.lastfm }}


### PR DESCRIPTION
MobyGames is a database of game developers, so this social link might be useful to game developers using the Blackburn theme.
