### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,8 +33,8 @@
   <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet" type="text/css">
 
   <!-- RSS -->
-  {{ if .RSSlink }}
-  <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSlink }}" />
+  {{ if .RSSLink }}
+  <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSLink }}" />
   {{ end }}
 
   {{ with .Site.Params.highlightjs }}

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,9 +1,9 @@
 <div class="pure-menu social">
   <ul class="pure-menu-list">
 
-    {{ if .RSSlink }}
+    {{ if .RSSLink }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="{{ .RSSlink }}"><i class="fa fa-rss fa-fw"></i>RSS</a>
+      <a class="pure-menu-link" href="{{ .RSSLink }}"><i class="fa fa-rss fa-fw"></i>RSS</a>
     </li>
     {{ end }}
 


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.