### PR TITLE
upgrade Highlight.js to 9.8.0 and add Go highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Blackburn is a clear and responsive theme for [Hugo](//gohugo.io).
   * Last.fm
   * Discogs
   * Keybase
-* Client-side syntax highlighting by [Highlight.js](//highlightjs.org) (v9.1.0)
+* Client-side syntax highlighting by [Highlight.js](//highlightjs.org) (v9.8.0)
 * Web analytics by Google Analytics
 * Comments by Disqus
 * Icons by Font Awesome (v4.5.0)

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,8 +38,9 @@
   {{ end }}
 
   {{ with .Site.Params.highlightjs }}
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.1.0/styles/{{ . }}.min.css">
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.1.0/highlight.min.js"></script>
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/styles/{{ . }}.min.css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/languages/go.min.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
   {{ end }}
 


### PR DESCRIPTION
I've  upgraded Hilight.js to 9.8.0 (many improvements and fixes since 9.1) + added link to Go Hilight.js file (it's distributed separately).