### PR TITLE
Per issue #49 safeHTMLAttr

### DIFF
--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -22,7 +22,7 @@
           </ul>
       {{else}}
         <li class="pure-menu-item">
-          <a class="pure-menu-link" href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a>
+          <a class="pure-menu-link" {{ printf "href=%q" .URL | safeHTMLAttr }}>{{ .Pre }}{{ .Name }}</a>
       {{end}}
         </li>
       {{end}}


### PR DESCRIPTION
Allow for xdg style links like bitcoin: or irc: in the
sidemenu.html file.