### PR TITLE
Fix archetype missing date and title warning

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,4 +1,6 @@
 +++
+title = "{{ replace .TranslationBaseName "-" " " | title }}"
+date = {{ .Date }}
 draft = true
 tags = []
 topics = []


### PR DESCRIPTION
Hugo 0.24 onward require the date and title to be provided in the archetype so I used some sane defaults.