### PR TITLE
Fix archetype generating date is not string type

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,6 @@
 +++
 title = "{{ replace .TranslationBaseName "-" " " | title }}"
-date = {{ .Date }}
+date = "{{ .Date }}"
 draft = true
 tags = []
 topics = []


### PR DESCRIPTION
fixed following error:
```
vagrant@vagrant-ubuntu-trusty-64:~/myblog$ hugo new post/test2.md
/home/vagrant/myblog/content/post/test2.md created
vagrant@vagrant-ubuntu-trusty-64:~/myblog$ hugo undraft content/post/test2.md
panic: interface conversion: interface {} is time.Time, not string

goroutine 1 [running]:
github.com/gohugoio/hugo/commands.undraftContent(0xf59420, 0xc420043580, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/bep/go/src/github.com/gohugoio/hugo/commands/undraft.go:111 +0xad7
github.com/gohugoio/hugo/commands.Undraft(0xfa7700, 0xc420012b50, 0x1, 0x1, 0x0, 0x0)
        /Users/bep/go/src/github.com/gohugoio/hugo/commands/undraft.go:63 +0x1b5
github.com/gohugoio/hugo/vendor/github.com/spf13/cobra.(*Command).execute(0xfa7700, 0xc420012ad0, 0x1, 0x1, 0xfa7700, 0xc420012ad0)
        /Users/bep/go/src/github.com/gohugoio/hugo/vendor/github.com/spf13/cobra/command.go:649 +0x457
github.com/gohugoio/hugo/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xfa5c00, 0xc0f6a0, 0x4045ac, 0xc4200180b8)
        /Users/bep/go/src/github.com/gohugoio/hugo/vendor/github.com/spf13/cobra/command.go:728 +0x339
github.com/gohugoio/hugo/commands.Execute()
        /Users/bep/go/src/github.com/gohugoio/hugo/commands/hugo.go:173 +0x60
main.main()
        /Users/bep/go/src/github.com/gohugoio/hugo/main.go:27 +0x36
```