### PR TITLE
Fixed the formatting of URL to PureCSS #

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blackburn is a clear and responsive theme for [Hugo](//gohugo.io).
 
 ## Overview
 
-* Based on Yahoo's [Pure CSS] (http://purecss.io/) (v1.0.0)
+* Based on Yahoo's [Pure CSS](http://purecss.io/) (v1.0.0)
 * Fixed sidebar with social links:
   * Twitter
   * GNU social


### PR DESCRIPTION
The markdown in the README file had a formatting issue because of which the text `Pure CSS` was not displayed as the label for the URL. This PR fixes that issue.