### PR TITLE
New shortcode "pure_table" to create tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ paginate = 10
 
 ## Shortcodes
 
+### pure_table
+```
+{{< pure_table
+  "columnName1|columnName2|...|columnName99"
+  "dataValue1|dataValue2|...|dataValue99"
+  "dataValue1|dataValue2|...|dataValue99"
+  "dataValue1|dataValue2|...|dataValue99"
+  "... and so on"
+>}}
+```
+
+where each positional parameter is separated by the vertical bar (i.e., |). The resulting `<table>` is set to have `class="pure-table pure-table-striped"`.
+
 ### fluid_imgs
 
 ```

--- a/layouts/shortcodes/pure_table.html
+++ b/layouts/shortcodes/pure_table.html
@@ -1,0 +1,20 @@
+{{ $fields := (index .Params 0) }}
+{{ $data := after 1 .Params }}
+
+<table class="pure-table pure-table-striped">
+  <thead><tr>
+    {{ range split $fields "|"}}
+      <th>{{ . }}</th>
+    {{ end }}
+  </thead></tr>
+  <tbody>
+  {{ range $data}}
+    <tr>
+      {{ $items := split . "|" }}
+      {{ range $items }}
+        <td>{{ . }}</td>
+      {{ end }}
+    </tr>
+  {{ end }}
+  </tbody>
+</table>


### PR DESCRIPTION
Example usage at the bottom of this post:
http://charlesjlee.com/post/20170108-steem-bot/
```
{{<pure_table
    "key|example value|comment"
    "numPostsToConsider|20|Number of recent posts to consider"
    "percentChanceToPost|5|Percent chance that script will run. Must be between 0 and 100"
    "steemAccountName|'mySteemName'|Your Steem account name wrapped in single quotes"
    "steemPostingKey|'myPrivatePostingKey'|Your Private Posting Key that you saved when creating your SteemIt account, wrapped in single quotes"
    "voteWeight|100|How much voting power to use per upvote. Note that voting power decreases after every vote. Must be between 0 and 100"
>}}
```