### PR TITLE
Add mathjax partials (and capabilities) to Blackburn theme.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,6 +4,8 @@
 
 {{ partial "google_analytics.html" . }}
 {{ partial "piwik_analytics.html" . }}
+{{ partial "footer_mathjax" . }}
+
 
 </body>
 </html>

--- a/layouts/partials/footer_mathjax.html
+++ b/layouts/partials/footer_mathjax.html
@@ -1,0 +1,4 @@
+{{ if and (not .Params.disable_mathjax) (or (in (string .Content) "\\") (in (string .Content) "$")) }}
+<script src="{{ "/js/math-code.js" | relURL }}"></script>
+  <script async src="{{ .Site.Params.MathJaxCDN | default "//cdn.bootcss.com" }}/mathjax/{{ .Site.Params.MathJaxVersion | default "2.7.1" }}/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+  {{ end }}


### PR DESCRIPTION
I had to add the mathjax partials to the theme when I pulled it for my Hugo blog. It looked like the partial`footer_mathjax.html` and the partial reference in `footer.html` were missing. Once I added those to my local copy of Blackburn, I had mathjax capabilities immediately. Thought I'd make a PR just so they're updated for whoever comes next.