### PR TITLE
Allow external JS and CSS to be included

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,18 +187,18 @@ paginate = 10
   url = "/about/"
 ```
 
-* Override the theme by linking to custom CSS files:
+* Override the theme by linking to custom CSS files or URLs:
 
 ```toml
 [params]
   custom_css = ["css/my.css"]
 ```
 
-* Add new behaviours by linking to custom JS files:
+* Add new behaviours by linking to custom JS files or URLs:
 
 ```toml
 [params]
-  custom_js = ["js/my.js"]
+  custom_js = ["js/my.js", "https://cdnjs.cloudflare.com/ajax/libs/zooming/1.4.2/zooming.min.js"]
 ```
 
 ## Shortcodes

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -52,10 +52,18 @@
   {{ partial "favicon.html" . }}
 
   {{ range .Site.Params.custom_css }}
-    <link rel="stylesheet" href="{{ $.Site.BaseURL }}{{ . }}">
+    {{ if findRE "https?://" . }}
+        <link rel="stylesheet" href="{{ . }}">
+    {{ else }}
+        <link rel="stylesheet" href="{{ $.Site.BaseURL }}{{ . }}">
+    {{ end }}
   {{ end }}
   {{ range .Site.Params.custom_js }}
-    <script src="{{ $.Site.BaseURL }}{{ . }}"></script>
+    {{ if findRE "https?://" . }}
+        <script src="{{ . }}"></script>
+    {{ else }}
+        <script src="{{ $.Site.BaseURL }}{{ . }}"></script>
+    {{ end }}
   {{ end }}
 
 </head>


### PR DESCRIPTION
Allow params.custom_css and params.custom_js to contain HTTP and HTTPS
URLs.