### PR TITLE
hugo v0.35 modified archetype value

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,5 +1,5 @@
 +++
-title = "{{ replace .TranslationBaseName "-" " " | title }}"
+title = "{{ replace .Name "-" " " | title }}"
 date = "{{ .Date }}"
 draft = true
 tags = []


### PR DESCRIPTION
Starting with v0.35 TranslationBaseName was replaced for Name on the archetype template. 

See https://github.com/gohugoio/hugo/commit/863a812e07193541b42732b0e227f3d320433f01