### PR TITLE
Disable google analytics on localhost

### DIFF
--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -1,12 +1,14 @@
 {{ with .Site.Params.googleAnalytics }}
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  // Never report traffic that originates from local testing.
+  if (window.location.hostname != "localhost") {
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '{{ . }}', 'auto');
-  ga('send', 'pageview');
-
+    ga('create', '{{ . }}', 'auto');
+    ga('send', 'pageview');
+  }
 </script>
 {{ end }}


### PR DESCRIPTION
Disable google analytics when working from localhost. There is precedent for this in [`disqus.html`](https://github.com/yoshiharuyamashita/blackburn/blob/1bd3b1a49e8bc7f1236377fb8d65d947fc6f8af7/layouts/partials/disqus.html#L8). Without this change, traffic will be reported to google, which is inaccurate, and can mess up stats by counting local traffic.

You can see this in action on my [blog](https://blog.jamesotten.com/).