### PR TITLE
Update deprecated Page variables: .Prev & .Next

### DIFF
--- a/layouts/partials/prev_next_post.html
+++ b/layouts/partials/prev_next_post.html
@@ -1,4 +1,4 @@
-{{ if or (.Prev) (.Next) }}
+{{ if or (.NextPage) (.PrevPage) }}
 <div class="prev-next-post pure-g">
   <div class="pure-u-1-24" style="text-align: left;">
     {{ if .PrevInSection }}


### PR DESCRIPTION
Using command "hugo server" with v0.51 gives the following messages:
WARNING: Page's .Prev is deprecated and will be removed in a future release. Use .NextPage (yes, not .PrevPage).
WARNING: Page's .Next is deprecated and will be removed in a future release. Use .PrevPage (yes, not .NextPage). 