### PR TITLE
Add canonical header link from content preamble

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,6 +6,10 @@
 
   <title>{{ if .IsHome }}{{ .Title }}{{ else }}{{ .Title }} &middot; {{ .Site.Title }}{{ end }}</title>
 
+    {{ if .Params.canonical }}
+    <link rel="canonical" href="{{ .Params.canonical }}">
+    {{ end }}
+
   <!-- CSS -->
   {{ $purecss := "https://cdnjs.cloudflare.com/ajax/libs/pure/1.0.0/" }}
   <link rel="stylesheet" href="{{ $purecss }}pure-min.css">


### PR DESCRIPTION
Hey, I needed this functionality, and it might be a good addition to your codebase as well.

I need to publish my content, but I'm also obliged to point to canonical version of it (on third party blog that actually paid me to write it). So now I can 