### PR TITLE
Remove .Data.Pages in favor of .Site.RegularPages

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
 </div>
 
 <div class="content">
-  {{ range ( .Paginate (where .Data.Pages "Type" "post")).Pages }}
+  {{ range ( .Paginate (where .Site.RegularPages "Type" "post")).Pages }}
     {{ .Render "summary"}}
   {{ end }}
 


### PR DESCRIPTION
Using only .Data.Pages will only show a link to the Post page in the home page. Using .Site.RegularPages returns the homepage to a normal showcase of existing posts. This change happened starting at Hugo >0.57.