### PR TITLE
Add rss link in header for some rss reader to automatic find this.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
+{{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}
 
 {{ partial "head.html" . }}
 


### PR DESCRIPTION
As title.
I test on Firefox add-ons "[FreedBro](https://nodetics.com/feedbro/)" works find .
This code from official document [RSS Templates](https://gohugo.io/templates/rss/#reference-your-rss-feed-in-head).