### PR TITLE
Add support for Content Security Policy via an optional parameter

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,6 +2,9 @@
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="{{ if .IsNode }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ else }}{{ with .Description }}{{ . }}{{ end }}{{ end }}">
+  {{ with .Site.Params.csp }}
+  <meta http-equiv="Content-Security-Policy" content="{{ . | safeHTML }}">
+  {{ end }}
   {{hugo.Generator}}
 
   <title>{{ if .IsHome }}{{ .Title }}{{ else }}{{ .Title }} &middot; {{ .Site.Title }}{{ end }}</title>


### PR DESCRIPTION
Content Security Policy (CSP) is often used as a part of a defense in depth based approach to prevent common web vulnerabilities.

With this change, a user can setup their own CSP through an optional site parameter "csp".
If the parameter is set, a meta element is added to the page which contains the user's policy.

More info on CSP is available on MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP