### PR TITLE
Add support for Commento.io as a Disqus alternative.

### DIFF
--- a/layouts/partials/commento.html
+++ b/layouts/partials/commento.html
@@ -1,0 +1,6 @@
+{{ with .Site.Params.commento }}
+<div id="commento_thread"></div>
+<script defer src="https://cdn.commento.io/js/commento.js"></script>
+<div id="commento"></div>
+<noscript>This site uses privacy-respecting comments integration provided by <a href="https://commento.io/">Commento</a>.  Please enable Javascript to see comments.</noscript>
+{{ end }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -13,7 +13,9 @@
   {{ partial "share.html" . }}
 
   {{ partial "prev_next_post.html" . }}
-
+  
+  {{ partial "commento.html" . }}
+  
   {{ partial "disqus.html" . }}
 
 </div>


### PR DESCRIPTION
It's been quite some time since I worked on my website, but I started back up recently and I am concerned that this theme may be unmaintained since it has several pending PRs.  That said, I am going to open a few today to add some things I think are useful, this is the first.

Inspired by the recent thread on [HackerNews](https://news.ycombinator.com/item?id=26033052) about the misbehavior of Disqus I updated my website to use Commento.io instead as noted in my recent [post](https://tristor.ro/blog/2021/02/05/replacing-disqus-with-commento.io/).  There are other Disqus alternatives in market that are privacy respecting, including [Isso](https://posativ.org/isso/), but I chose Commento.io for a few different reasons.

Disqus unfortunately got acquired by an ad-tech company and they now use horrid behavior towards users, with significant added page weight and trackers which breaks the minimalism I was going for on my site with this theme.  I've tested and validated that this change works on my own site and you can see a "demo" of it, if you will, in the linked post above.  

Caveats/Cons to my changes:

* Commento.io isn't free for the hosted variety, which is the only method that my changes here support.
* I'm using the "with site param" method to basically act as an if-block for enabling Commento, but didn't know of a clean way to make this a boolean.  So right now it's just required that your config.toml contains /some/ string value for the param.

There's probably a cleaner way to implement this, but this was the most straightforward and it works.