### PR TITLE
Remove appended via= block from Twitter share button

### DIFF
--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -2,7 +2,7 @@
 <ul class="share-buttons">
 	<li><a href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" target="_blank" title="Share on Facebook"><i class="fa-facebook" aria-hidden="true"></i><span class="sr-only">Share on Facebook</span></a>
 	</li>&nbsp;&nbsp;&nbsp;
-	<li><a href="https://twitter.com/intent/tweet?source={{ .Permalink }}&via=HorribleGeek" target="_blank" title="Tweet"><i class="fa-twitter" aria-hidden="true"></i><span class="sr-only">Tweet</span></a>
+	<li><a href="https://twitter.com/intent/tweet?source={{ .Permalink }}" target="_blank" title="Tweet"><i class="fab fa-twitter" aria-hidden="true"></i><span class="sr-only">Tweet</span></a>
 	</li>&nbsp;&nbsp;&nbsp;
 	<li><a href="https://plus.google.com/share?url={{ .Permalink }}" target="_blank" title="Share on Google+"><i class="fa-google-plus" aria-hidden="true"></i><span class="sr-only">Share on Google+</span></a>
 	</li>&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
While fixing PR #106, I found that the Twitter share button built-in to this theme is appending a `via=` block which references the Twitter user @HorribleGeek. I'm guessing they may have contributed the original change to the theme and it missed being cleaned up.  This PR fixes this.