### PR TITLE
Adding in support for GoatCounter privacy respecting analytics.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,6 +3,7 @@
 <script src="{{ .Site.BaseURL }}js/ui.js"></script>
 <script src="{{ .Site.BaseURL }}js/menus.js"></script>
 
+{{ partial "goatcounter_analytics.html" . }}
 {{ partial "google_analytics.html" . }}
 {{ partial "piwik_analytics.html" . }}
 {{ partial "footer_mathjax" . }}

--- a/layouts/partials/goatcounter_analytics.html
+++ b/layouts/partials/goatcounter_analytics.html
@@ -1,0 +1,5 @@
+{{ with .Site.Params.goatcounterAnalytics }}
+<!-- GoatCounter -->
+<script data-goatcounter="https://{{ . }}.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
+{{ end }}


### PR DESCRIPTION
Following up on my changes in PR #106, I was also looking for alternatives to the default of Google Analytics.  I don't think I need to explain why Google Analytics isn't the best option from a privacy perspective or a page weight perspective.

There are numerous options out there, some of which I considered specifically which included [Plausible](https://plausible.io/), [Offen](https://www.offen.dev/), and obviously [GoatCounter](https://www.goatcounter.com/).  The big selling point for GoatCounter over other privacy-respecting alternatives is that it's a SaaS which has a free tier for NON-COMMERCIAL use.  This means folks who are hosting Hugo sites with this theme in places where they cannot deploy other services can still get analytics.  This was one motivator for why I picked Commento in PR #106 as well.

This changeset is relatively minimal, it adds a new partial, and a new param that must be set to your GoatCounter "code", which gets injected into the URL it loads for the script.  It works and has been tested on my personal website.

There may be a cleaner implementation strategy, but this seems to be about right.