### PR TITLE
Use CDNJS for MathJax instead of cdn.bootcss.com

### DIFF
--- a/layouts/partials/footer_mathjax.html
+++ b/layouts/partials/footer_mathjax.html
@@ -1,4 +1,4 @@
 {{ if and (not .Params.disable_mathjax) (or (in (string .Content) "\\") (in (string .Content) "$")) }}
 <script src="{{ "/js/math-code.js" | relURL }}"></script>
-  <script async src="{{ .Site.Params.MathJaxCDN | default "//cdn.bootcss.com" }}/mathjax/{{ .Site.Params.MathJaxVersion | default "2.7.1" }}/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+  <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"></script>
   {{ end }}


### PR DESCRIPTION
This patch you may not want to accept, but I'm submitting the PR to make it simple for others to take the patch if they wish in their own forks.  The reasoning is that I've removed what was previously a configurable set of parameters with some fallback logic to instead make a hardcoded decision that closely matches the prior default.

The sum total of this change is that it does the following:

1. Removes parameterization logic
2. Uses CloudFlare's CDNJS (which is recommended by the MathJax project) instead of cdn.bootcss.com, which was hanging infinitely for me on my site
3. Bumps the specific version requested from the previous 2.7.1 to 2.7.7, which is the last release in the 2.7 series and I confirmed didn't seem to break anything in my testing.