### PR TITLE
Add the recommended default section template into layouts/_default

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,0 +1,15 @@
+{{ define "main" }}
+  <main>
+      {{ .Content }}
+          <ul class="contents">
+          {{ range .Paginator.Pages }}
+              <li>{{.Title}}
+                  <div>
+                    {{ partial "summary.html" . }}
+                  </div>
+              </li>
+          {{ end }}
+          </ul>
+      {{ partial "pagination.html" . }}
+  </main>
+{{ end }}


### PR DESCRIPTION
I am not certain exactly when the change was made in Hugo, but I think it was sometime around 0.55 release.  This just adds the default section template from [the Hugo documentation](https://gohugo.io/templates/section-templates/) into the theme, which does not appear to break anything on my site.  This eliminates the [warning message](https://discourse.gohugo.io/t/found-no-layout-file-for-html/18983) that currently happens every time you build your site using blackburn.