### PR TITLE
Adds the fa-fw class to the some social icons missing this class.

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -18,7 +18,7 @@
 
     {{ with .Site.Social.gnusocial }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="{{ . }}" rel="me" target="_blank"><i class="fas fa-comment"></i>GNU social</a>
+      <a class="pure-menu-link" href="{{ . }}" rel="me" target="_blank"><i class="fas fa-comment fa-fw"></i>GNU social</a>
     </li>
     {{ end }}
 
@@ -140,7 +140,7 @@
 
     {{ with .Site.Social.bitbucket }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://bitbucket.org/{{ . }}" rel="me" target="_blank"><i class="fab fa-bitbucket"></i>Bitbucket</a>
+      <a class="pure-menu-link" href="https://bitbucket.org/{{ . }}" rel="me" target="_blank"><i class="fab fa-bitbucket fa-fw"></i>Bitbucket</a>
     </li>
     {{ end }}
 
@@ -166,7 +166,7 @@
 
     {{ with .Site.Social.mobygames }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://www.mobygames.com/developer/sheet/view/developerId,{{ . }}" rel="me" target="_blank"><i class="fas fa-gamepad"></i>MobyGames</a>
+      <a class="pure-menu-link" href="https://www.mobygames.com/developer/sheet/view/developerId,{{ . }}" rel="me" target="_blank"><i class="fas fa-gamepad fa-fw"></i>MobyGames</a>
     </li>
     {{ end }}
 
@@ -188,7 +188,7 @@
 
     {{ with .Site.Social.keybase }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://keybase.io/{{ . }}" rel="me" target="_blank"><i class="fas fa-key"></i>Keybase</a>
+      <a class="pure-menu-link" href="https://keybase.io/{{ . }}" rel="me" target="_blank"><i class="fas fa-key fa-fw"></i>Keybase</a>
     </li>
     {{ end }}
 

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -4,7 +4,7 @@
     {{ if .OutputFormats.Get "RSS" }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}'><i
-          class="fas fa-rss"></i>RSS</a>
+          class="fas fa-rss fa-fw"></i>RSS</a>
     </li>
     {{ end }}
 
@@ -100,7 +100,7 @@
 
     {{ with .Site.Social.linkedin }}
     <li class="pure-menu-item">
-      <a class="pure-menu-link" href="https://linkedin.com/in/{{ . }}" rel="me" target="_blank"><i class="fab fa-linkedin"></i></i>LinkedIn</a>
+      <a class="pure-menu-link" href="https://linkedin.com/in/{{ . }}" rel="me" target="_blank"><i class="fab fa-linkedin fa-fw"></i>LinkedIn</a>
     </li>
     {{ end }}
 


### PR DESCRIPTION
In `layouts/partials/social.html` there are a few icons missing the `fa-fw` class value, which are interestingly the only icons misaligned.  From the [Font Awesome docs](https://fontawesome.com/v4.7.0/examples/) this sets the icons to a fixed width, which seems reasonable for the sidebar.  This patch fixes the following icons to also have this set, and causes all icons to align on my system.

Icons affected:
* LinkedIn
* RSS
* GNU Social
* MobyGames
* BitBucket
* Keybase

