### PR TITLE
Revert async loading of main hljs

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -48,7 +48,7 @@
 
   {{ with .Site.Params.highlightjs }}
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/styles/{{ . }}.min.css">
-  <script async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/highlight.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/highlight.min.js"></script>
   {{ range $.Site.Params.highlightjs_extra_languages }}
   <script async src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/languages/{{ . }}.min.js"></script>
   {{ end }}


### PR DESCRIPTION
Having the main hljs loading asynchronously makes the code blocks bug, since the
page throws hljs is undefined on hljs.initHighlightOnLoad called just after.