### PR TITLE
Fixed a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Blackburn is a clear and responsive theme for [Hugo](//gohugo.io).
 
 ## Demo
 
-* [Demo](http://themes.gohugo.io/theme/blackburn/)
+* [Demo](http://themes.gohugo.io/themes/blackburn/)
 * You can also see it in action on my personal website [here](http://yoshiharuyamashita.com/)
 
 ## Screenshots


### PR DESCRIPTION
I tried accessing this link, but I got a 404. I searched on Hugo website, found that Hugo changed from `https://themes.gohugo.io/theme/` to `https://themes.gohugo.io/themes/`.