### PR TITLE
Fixes several deprecated items in the them aligned to Hugo version 0.139

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ author = "Your name"
 # Shown in the side menu
 copyright = "&copy; 2016. All rights reserved."
 canonifyurls = true
-paginate = 10
+
+[pagination]
+pagerSize = 10
 
 [indexes]
   tag = "tags"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ pagerSize = 10
     weight = 4
     url = "/contact/"
 
-[social]
+[params.social]
   # Link your social networking accounts to the side menu
   # by entering your username or ID.
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -49,7 +49,7 @@ pagerSize = 10
     weight = 4
     url = "/contact/"
 
-[social]
+[params.social]
   # Link your social networking accouns to the side menu
   # by entering your username or ID.
   twitter="*"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,7 +5,9 @@ theme = "blackburn"
 author = "Yoshiharu Yamashita"
 copyright = "&copy; 2016. All rights reserved."
 canonifyurls = true
-paginate = 10
+
+[pagination]
+pagerSize = 10
 
 [indexes]
   tag = "tags"

--- a/layouts/partials/prev_next_post.html
+++ b/layouts/partials/prev_next_post.html
@@ -1,4 +1,4 @@
-{{ if or (.NextPage) (.PrevPage) }}
+{{ if or (.Next) (.Prev) }}
 <div class="prev-next-post pure-g">
   <div class="pure-u-1-24" style="text-align: left;">
     {{ if .PrevInSection }}

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -10,31 +10,31 @@
 
     <!-- SNS microblogging -->
 
-    {{ with .Site.Social.twitter }}
+    {{ with .Site.Params.Social.twitter }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://twitter.com/{{ . }}" rel="me" target="_blank"><i class="fab fa-twitter-square fa-fw"></i>Twitter</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.gnusocial }}
+    {{ with .Site.Params.Social.gnusocial }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="{{ . }}" rel="me" target="_blank"><i class="fas fa-comment fa-fw"></i>GNU social</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.facebook }}
+    {{ with .Site.Params.Social.facebook }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://facebook.com/{{ . }}" rel="me" target="_blank"><i class="fab fa-facebook-square fa-fw"></i>Facebook</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.weibo }}
+    {{ with .Site.Params.Social.weibo }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="http://weibo.com/{{ . }}" rel="me" target="_blank"><i class="fab fa-weibo fa-fw"></i>Weibo</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.tumblr }}
+    {{ with .Site.Params.Social.tumblr }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://{{ . }}.tumblr.com/" rel="me" target="_blank"><i class="fab fa-tumblr-square fa-fw"></i>Tumblr</a>
     </li>
@@ -42,49 +42,49 @@
 
     <!-- SNS photo/video sharing -->
 
-    {{ with .Site.Social.instagram }}
+    {{ with .Site.Params.Social.instagram }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://instagram.com/{{ . }}" rel="me" target="_blank"><i class="fab fa-instagram fa-fw"></i>Instagram</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.flickr }}
+    {{ with .Site.Params.Social.flickr }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://flickr.com/photos/{{ . }}" rel="me" target="_blank"><i class="fab fa-flickr fa-fw"></i>Flickr</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.photo500px }}
+    {{ with .Site.Params.Social.photo500px }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://500px.com/{{ . }}" rel="me" target="_blank"><i class="fab fa-500px fa-fw"></i>500px</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.pinterest }}
+    {{ with .Site.Params.Social.pinterest }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://pinterest.com/{{ . }}" rel="me" target="_blank"><i class="fab fa-pinterest-square fa-fw"></i>Pinterest</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.youtube }}
+    {{ with .Site.Params.Social.youtube }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://youtube.com/user/{{ . }}" rel="me" target="_blank"><i class="fab fa-youtube-square fa-fw"></i>YouTube</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.vimeo }}
+    {{ with .Site.Params.Social.vimeo }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://vimeo.com/{{ . }}" rel="me" target="_blank"><i class="fab fa-vimeo-square fa-fw"></i>Vimeo</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.vine }}
+    {{ with .Site.Params.Social.vine }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://vine.co/{{ . }}" rel="me" target="_blank"><i class="fab fa-vine fa-fw"></i>Vine</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.slideshare }}
+    {{ with .Site.Params.Social.slideshare }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="http://slideshare.net/{{ . }}" rel="me" target="_blank"><i class="fab fa-slideshare fa-fw"></i>SlideShare</a>
     </li>
@@ -92,13 +92,13 @@
 
     <!-- SNS career oriented -->
 
-    {{ with .Site.Social.linkedin }}
+    {{ with .Site.Params.Social.linkedin }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://linkedin.com/in/{{ . }}" rel="me" target="_blank"><i class="fab fa-linkedin fa-fw"></i>LinkedIn</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.xing }}
+    {{ with .Site.Params.Social.xing }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://xing.com/profile/{{ . }}" rel="me" target="_blank"><i class="fab fa-xing-square fa-fw"></i>Xing</a>
     </li>
@@ -106,13 +106,13 @@
 
     <!-- SNS news -->
 
-    {{ with .Site.Social.reddit }}
+    {{ with .Site.Params.Social.reddit }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://reddit.com/user/{{ . }}" rel="me" target="_blank"><i class="fab fa-reddit-square fa-fw"></i>Reddit</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.hackernews }}
+    {{ with .Site.Params.Social.hackernews }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://news.ycombinator.com/user?id={{ . }}" rel="me" target="_blank"><i class="fab fa-hacker-news fa-fw"></i>Hacker News</a>
     </li>
@@ -120,31 +120,31 @@
 
     <!-- Techie -->
 
-    {{ with .Site.Social.github }}
+    {{ with .Site.Params.Social.github }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://github.com/{{ . }}" rel="me" target="_blank"><i class="fab fa-github-square fa-fw"></i>GitHub</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.gitlab }}
+    {{ with .Site.Params.Social.gitlab }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://gitlab.com/{{ . }}" rel="me" target="_blank"><i class="fab fa-gitlab fa-fw"></i>GitLab</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.bitbucket }}
+    {{ with .Site.Params.Social.bitbucket }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://bitbucket.org/{{ . }}" rel="me" target="_blank"><i class="fab fa-bitbucket fa-fw"></i>Bitbucket</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.stackoverflow }}
+    {{ with .Site.Params.Social.stackoverflow }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://stackoverflow.com/users/{{ . }}" rel="me" target="_blank"><i class="fab fa-stack-overflow fa-fw"></i>Stack Overflow</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.serverfault }}
+    {{ with .Site.Params.Social.serverfault }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://serverfault.com/users/{{ . }}" rel="me" target="_blank"><i class="fab fa-server fa-fw"></i>Server Fault</a>
     </li>
@@ -152,13 +152,13 @@
 
     <!-- Gaming -->
 
-    {{ with .Site.Social.steam }}
+    {{ with .Site.Params.Social.steam }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://steamcommunity.com/id/{{ . }}" rel="me" target="_blank"><i class="fab fa-steam-square fa-fw"></i>Steam</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.mobygames }}
+    {{ with .Site.Params.Social.mobygames }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://www.mobygames.com/developer/sheet/view/developerId,{{ . }}" rel="me" target="_blank"><i class="fas fa-gamepad fa-fw"></i>MobyGames</a>
     </li>
@@ -166,13 +166,13 @@
 
     <!-- Music -->
 
-    {{ with .Site.Social.lastfm }}
+    {{ with .Site.Params.Social.lastfm }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="http://last.fm/user/{{ . }}" rel="me" target="_blank"><i class="fab fa-lastfm-square fa-fw"></i>Last.fm</a>
     </li>
     {{ end }}
 
-    {{ with .Site.Social.discogs }}
+    {{ with .Site.Params.Social.discogs }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://www.discogs.com/user/{{ . }}" rel="me" target="_blank"><i class="fab fa-music fa-fw"></i>Discogs</a>
     </li>
@@ -180,7 +180,7 @@
 
     <!-- Other -->
 
-    {{ with .Site.Social.keybase }}
+    {{ with .Site.Params.Social.keybase }}
     <li class="pure-menu-item">
       <a class="pure-menu-link" href="https://keybase.io/{{ . }}" rel="me" target="_blank"><i class="fas fa-key fa-fw"></i>Keybase</a>
     </li>


### PR DESCRIPTION
There were errors when doing a Hugo build due to deprecations after updating to the latest release, currently version 0.139.

Specifically this resolves three issues:

1. Site.Social is deprecated in favor of Site.Params.Social
2. Page.NextPage and Page.PrevPage are deprecated in favor of Page.Next and Page.Prev
3. Config parameter paginate is deprecated in favor of paginator.pagerSize

With these changes, it builds cleanly without my other changes.